### PR TITLE
Increase the search debounce time to about one second

### DIFF
--- a/packages/nyris-webapp/src/epics/feedback.ts
+++ b/packages/nyris-webapp/src/epics/feedback.ts
@@ -19,7 +19,7 @@ const feedbackSuccessEpic: EpicConf = (action$, state$, {api}) => action$.pipe(
 
 const feedbackRegionEpic: EpicConf = (action$, state$, {api}) => action$.pipe(
     ofType('REGION_CHANGED'),
-    debounceTime(600),
+    debounceTime(1200),
     withLatestFrom(state$),
     tap(async ([action, state]) => {
         if (action.type === 'REGION_CHANGED') {

--- a/packages/nyris-webapp/src/epics/index.ts
+++ b/packages/nyris-webapp/src/epics/index.ts
@@ -102,7 +102,7 @@ const startSearchOnRegionsSuccessful: EpicConf = (action$, state$) => action$.pi
 
 const startSearchOnRegionChange: EpicConf = (action$, state$) => action$.pipe(
     ofType('REGION_CHANGED'),
-    debounceTime(600),
+    debounceTime(1200),
     withLatestFrom(state$),
     switchMap(async ([action, { search: { requestImage}}]) : Promise<AppAction> => {
         if (action.type !== 'REGION_CHANGED') {


### PR DESCRIPTION
This addresses a wish to make it easier to modify the crop region before a new search is issued.

It is implemented by doubling the debounce time from 600ms to 1200ms. This follows the argument that it is better to wait a little bit longer before the request than having to wait for an unwanted request to be finished.

Ideally we would make this configurable, but that's a bit beyond my knowledge of this project.