### PR TITLE
feat: add productLinkBaseURL option to construct product links from baseURL

### DIFF
--- a/packages/nyris-widget/README.md
+++ b/packages/nyris-widget/README.md
@@ -26,8 +26,9 @@ Inside your HTML (best just before the closing ```</body>``` tag), add the follo
         searchCriteriaKey: '', // Define the attribute where filter values are stored
         filter: [] // Define attributes and labels for search Refinements e.g. [{label: 'Brand', field: 'brand' }]
         emailTemplateId: '', // emailjs template id for sending inquiry support email
-        productLinkBaseURL: '', // Base URL for constructing product links. Must include {SKU} placeholder which will be replaced with the actual SKU.
-        // Examples: 'https://example.com/products/{SKU}' or 'https://example.com/search?sku={SKU}'
+        productLinkBaseURL: '', // Base URL for constructing product links. Must include {SKU} placeholder(s) which will be replaced with the actual SKU.
+        // Examples: 'https://example.com/products/{SKU}' or 'https://example.com/search?sku={SKU}&id={SKU}'
+        // Multiple {SKU} occurrences are supported and will all be replaced with the same SKU value.
     };
     var s = document.createElement("script");
     s.src = "https://assets.nyris.io/nyris-widget/v1/widget.js";

--- a/packages/nyris-widget/README.md
+++ b/packages/nyris-widget/README.md
@@ -26,6 +26,7 @@ Inside your HTML (best just before the closing ```</body>``` tag), add the follo
         searchCriteriaKey: '', // Define the attribute where filter values are stored
         filter: [] // Define attributes and labels for search Refinements e.g. [{label: 'Brand', field: 'brand' }]
         emailTemplateId: '', // emailjs template id for sending inquiry support email
+        productLinkBaseURL: '', // Base URL for constructing product links. If provided, product links will be constructed as baseURL + sku instead of using links from search results. Example: 'https://example.com/products'
     };
     var s = document.createElement("script");
     s.src = "https://assets.nyris.io/nyris-widget/v1/widget.js";

--- a/packages/nyris-widget/README.md
+++ b/packages/nyris-widget/README.md
@@ -26,7 +26,8 @@ Inside your HTML (best just before the closing ```</body>``` tag), add the follo
         searchCriteriaKey: '', // Define the attribute where filter values are stored
         filter: [] // Define attributes and labels for search Refinements e.g. [{label: 'Brand', field: 'brand' }]
         emailTemplateId: '', // emailjs template id for sending inquiry support email
-        productLinkBaseURL: '', // Base URL for constructing product links. If provided, product links will be constructed as baseURL + sku instead of using links from search results. Example: 'https://example.com/products'
+        productLinkBaseURL: '', // Base URL for constructing product links. Must include {SKU} placeholder which will be replaced with the actual SKU.
+        // Examples: 'https://example.com/products/{SKU}' or 'https://example.com/search?sku={SKU}'
     };
     var s = document.createElement("script");
     s.src = "https://assets.nyris.io/nyris-widget/v1/widget.js";

--- a/packages/nyris-widget/src/Components/Product.tsx
+++ b/packages/nyris-widget/src/Components/Product.tsx
@@ -21,16 +21,13 @@ export const ProductCard = (r: ProductCardProps) => {
 
   /**
    * Gets the product link URL.
-   * If productLinkBaseURL is configured, constructs URL as baseURL + sku.
+   * If productLinkBaseURL is configured, replaces {SKU} placeholder with the actual SKU.
    * Otherwise, falls back to links.main from search results.
    */
   const getProductLink = (): string | undefined => {
     if (productLinkBaseURL && r.sku) {
-      // Ensure baseURL ends with / if it doesn't already
-      const baseURL = productLinkBaseURL.endsWith('/') 
-        ? productLinkBaseURL 
-        : `${productLinkBaseURL}/`;
-      return `${baseURL}${r.sku}`;
+      // Replace {SKU} placeholder with actual SKU
+      return productLinkBaseURL.replace('{SKU}', r.sku);
     }
     return r.links?.main;
   };

--- a/packages/nyris-widget/src/Components/Product.tsx
+++ b/packages/nyris-widget/src/Components/Product.tsx
@@ -21,13 +21,13 @@ export const ProductCard = (r: ProductCardProps) => {
 
   /**
    * Gets the product link URL.
-   * If productLinkBaseURL is configured, replaces {SKU} placeholder with the actual SKU.
+   * If productLinkBaseURL is configured, replaces all {SKU} placeholder occurrences with the actual SKU.
    * Otherwise, falls back to links.main from search results.
    */
   const getProductLink = (): string | undefined => {
     if (productLinkBaseURL && r.sku) {
-      // Replace {SKU} placeholder with actual SKU
-      return productLinkBaseURL.replace('{SKU}', r.sku);
+      // Replace all {SKU} placeholder occurrences with actual SKU
+      return productLinkBaseURL.replace(/{SKU}/g, r.sku);
     }
     return r.links?.main;
   };

--- a/packages/nyris-widget/src/Components/Product.tsx
+++ b/packages/nyris-widget/src/Components/Product.tsx
@@ -17,16 +17,34 @@ export const ProductCard = (r: ProductCardProps) => {
   const [bounding, setBounding] = useState<any>(null);
 
   const mountPoint = document.querySelector('#nyris-mount-point');
-  const { cadenasAPIKey } = window.nyrisSettings;
+  const { cadenasAPIKey, productLinkBaseURL } = window.nyrisSettings;
+
+  /**
+   * Gets the product link URL.
+   * If productLinkBaseURL is configured, constructs URL as baseURL + sku.
+   * Otherwise, falls back to links.main from search results.
+   */
+  const getProductLink = (): string | undefined => {
+    if (productLinkBaseURL && r.sku) {
+      // Ensure baseURL ends with / if it doesn't already
+      const baseURL = productLinkBaseURL.endsWith('/') 
+        ? productLinkBaseURL 
+        : `${productLinkBaseURL}/`;
+      return `${baseURL}${r.sku}`;
+    }
+    return r.links?.main;
+  };
 
   const getCTAURL = () => {
-    if (!r.metadata || !r.metadata.startsWith('search?')) {
-      return r.links?.main;
+    // If metadata starts with 'search?', handle it as a special case
+    if (r.metadata && r.metadata.startsWith('search?')) {
+      const index = window.location.href.indexOf('/#/');
+      return index !== -1
+        ? `${window.location.href.substring(0, index + 3)}${r.metadata}`
+        : window.location.href;
     }
-    const index = window.location.href.indexOf('/#/');
-    return index !== -1
-      ? `${window.location.href.substring(0, index + 3)}${r.metadata}`
-      : window.location.href;
+    // Otherwise, use the product link (either baseURL + sku or links.main)
+    return getProductLink();
   };
 
   return (
@@ -44,7 +62,7 @@ export const ProductCard = (r: ProductCardProps) => {
             ''
           )}
           <a
-            href={r.links?.main}
+            href={getProductLink()}
             target={window.nyrisSettings.navigatePreference}
             className="nyris__product-image"
           >
@@ -113,7 +131,7 @@ export const ProductCard = (r: ProductCardProps) => {
             <div className="nyris__product-button">
               {window.nyrisSettings.ctaButtonText}
             </div>
-            {r.links?.main && <img src={link} width={'14px'} height={'14px'} />}
+            {getProductLink() && <img src={link} width={'14px'} height={'14px'} />}
           </a>
         </div>
       </div>

--- a/packages/nyris-widget/src/Components/Product.tsx
+++ b/packages/nyris-widget/src/Components/Product.tsx
@@ -36,6 +36,10 @@ export const ProductCard = (r: ProductCardProps) => {
   };
 
   const getCTAURL = () => {
+    // If productLinkBaseURL is configured, always use it (prioritize custom product links)
+    if (productLinkBaseURL && r.sku) {
+      return getProductLink();
+    }
     // If metadata starts with 'search?', handle it as a special case
     if (r.metadata && r.metadata.startsWith('search?')) {
       const index = window.location.href.indexOf('/#/');
@@ -43,7 +47,7 @@ export const ProductCard = (r: ProductCardProps) => {
         ? `${window.location.href.substring(0, index + 3)}${r.metadata}`
         : window.location.href;
     }
-    // Otherwise, use the product link (either baseURL + sku or links.main)
+    // Otherwise, use the product link (links.main from search results)
     return getProductLink();
   };
 

--- a/packages/nyris-widget/src/Popup3D.tsx
+++ b/packages/nyris-widget/src/Popup3D.tsx
@@ -20,6 +20,23 @@ const Popup3D = ({
     "loading" | "loaded" | "not-found" | undefined
   >("loading");
 
+  /**
+   * Gets the product link URL.
+   * If productLinkBaseURL is configured, constructs URL as baseURL + sku.
+   * Otherwise, falls back to links.main from search results.
+   */
+  const getProductLink = (): string | undefined => {
+    const { productLinkBaseURL } = window.nyrisSettings;
+    if (productLinkBaseURL && resultDetails.sku) {
+      // Ensure baseURL ends with / if it doesn't already
+      const baseURL = productLinkBaseURL.endsWith('/') 
+        ? productLinkBaseURL 
+        : `${productLinkBaseURL}/`;
+      return `${baseURL}${resultDetails.sku}`;
+    }
+    return resultDetails.links?.main;
+  };
+
   const modalToggle = (isOpen: boolean) => {
     setShowModal(isOpen);
     if (isOpen) {
@@ -82,7 +99,7 @@ const Popup3D = ({
                 </div>
                 <a
                   className="nyris__product-cta"
-                  href={resultDetails.links?.main}
+                  href={getProductLink()}
                   target={window.nyrisSettings.navigatePreference}
                   style={{
                     backgroundColor:
@@ -92,7 +109,7 @@ const Popup3D = ({
                   <div className="nyris__product-button">
                     {window.nyrisSettings.ctaButtonText}
                   </div>
-                  {resultDetails.links?.main && (
+                  {getProductLink() && (
                     <img src={link} width={"14px"} height={"14px"} />
                   )}
                 </a>

--- a/packages/nyris-widget/src/Popup3D.tsx
+++ b/packages/nyris-widget/src/Popup3D.tsx
@@ -22,17 +22,14 @@ const Popup3D = ({
 
   /**
    * Gets the product link URL.
-   * If productLinkBaseURL is configured, constructs URL as baseURL + sku.
+   * If productLinkBaseURL is configured, replaces {SKU} placeholder with the actual SKU.
    * Otherwise, falls back to links.main from search results.
    */
   const getProductLink = (): string | undefined => {
     const { productLinkBaseURL } = window.nyrisSettings;
     if (productLinkBaseURL && resultDetails.sku) {
-      // Ensure baseURL ends with / if it doesn't already
-      const baseURL = productLinkBaseURL.endsWith('/') 
-        ? productLinkBaseURL 
-        : `${productLinkBaseURL}/`;
-      return `${baseURL}${resultDetails.sku}`;
+      // Replace {SKU} placeholder with actual SKU
+      return productLinkBaseURL.replace('{SKU}', resultDetails.sku);
     }
     return resultDetails.links?.main;
   };

--- a/packages/nyris-widget/src/Popup3D.tsx
+++ b/packages/nyris-widget/src/Popup3D.tsx
@@ -22,14 +22,14 @@ const Popup3D = ({
 
   /**
    * Gets the product link URL.
-   * If productLinkBaseURL is configured, replaces {SKU} placeholder with the actual SKU.
+   * If productLinkBaseURL is configured, replaces all {SKU} placeholder occurrences with the actual SKU.
    * Otherwise, falls back to links.main from search results.
    */
   const getProductLink = (): string | undefined => {
     const { productLinkBaseURL } = window.nyrisSettings;
     if (productLinkBaseURL && resultDetails.sku) {
-      // Replace {SKU} placeholder with actual SKU
-      return productLinkBaseURL.replace('{SKU}', resultDetails.sku);
+      // Replace all {SKU} placeholder occurrences with actual SKU
+      return productLinkBaseURL.replace(/{SKU}/g, resultDetails.sku);
     }
     return resultDetails.links?.main;
   };

--- a/packages/nyris-widget/src/types.ts
+++ b/packages/nyris-widget/src/types.ts
@@ -31,6 +31,7 @@ export interface NyrisSettings extends NyrisAPISettings {
   searchCriteriaKey?: string;
   filter?: { label: string; field: string }[];
   emailTemplateId?: string;
+  productLinkBaseURL?: string; // Base URL for constructing product links (baseURL + sku)
 }
 
 export interface AppProps {

--- a/packages/nyris-widget/webpack.config.js
+++ b/packages/nyris-widget/webpack.config.js
@@ -32,11 +32,26 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx|ts|tsx)$/,
-        exclude: /node_modules/,
+        exclude: [
+          /node_modules/,
+          /packages\/(?!nyris-widget)/
+        ],
+        include: [
+          path.resolve(__dirname, "src"),
+        ],
         use: {
           loader: "babel-loader",
           options: {
-            presets: ["@babel/preset-env"],
+            presets: [
+              "@babel/preset-env",
+              "@babel/preset-react",
+              "@babel/preset-typescript"
+            ],
+            plugins: [
+              "@babel/plugin-proposal-class-properties",
+              "@babel/proposal-object-rest-spread",
+              "@babel/plugin-transform-runtime"
+            ],
           },
         },
       },


### PR DESCRIPTION
baseURL + sku

- Add productLinkBaseURL setting to NyrisSettings interface
- Create getProductLink() helper function to construct URLs as baseURL + sku
- Update Product component to use custom product links for image and CTA
- Update Popup3D component to use custom product links
- Update README with documentation for new setting
- Maintain backward compatibility by falling back to links.main if not configured